### PR TITLE
Solve the problem with the Program file issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 TSMClient/
+8.1.2.0-TIV-TSMBAC-WinX64.exe
+vcredist.log

--- a/Config/ba_dsm.opt
+++ b/Config/ba_dsm.opt
@@ -12,9 +12,9 @@ SSL Yes
 Managedservices Webclient Schedule
 
 ErrorLogRetention 14 D
-Errorlogname	PATHTOERRORLOG
+Errorlogname	"PATHTOERRORLOG"
 SchedLogRetention 14 D
-Schedlogname	PATHTOSCHEDLOG
+Schedlogname	"PATHTOSCHEDLOG"
 
 Domain All-Local
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 ##################################################################################
 ##  Silent Installation Script for IBM Spectrum Protect Backup-Archive Client   ##
 ##  Made by Cristie Nordic AB                                                   ##
-##  Version 0.02                                                                ## 
+##  Version 0.03                                                                ##
 ##  Goes under MIT License Terms & Conditions                                   ##
 ##################################################################################
 
@@ -12,7 +12,7 @@ Function Get-InstallConfig {
     echo ""
 
     ####### IBM Spectrum Protect Server Settings #######
-    $Global:TcpServerAddressDefault = "tsm2.corp.com"
+    $Global:TcpServerAddressDefault = "tsm.corp.com"
     $Global:TcpPortDefault = "1500"
     $Global:NodePassword = "PASSWORD"
 
@@ -290,20 +290,8 @@ Function Test-BaClient {
             "set",
             "password",
             "$NodeName",
+            "$NodePassword",
             "$NodePassword"
-            "$NodePassword"
-            )
-    Start-Process -FilePath "dsmc.exe" -ArgumentList "$Argument" -Wait
-    
-    $Argument = @(
-            "query",
-            "filesystem"
-            )
-    Start-Process -FilePath "dsmc.exe" -ArgumentList "$Argument" -Wait
-
-    $Argument = @(
-            "query",
-            "schedule"
             )
     Start-Process -FilePath "dsmc.exe" -ArgumentList "$Argument" -Wait
 }


### PR DESCRIPTION
Solve the problem with the Program file that was created in the system root.
The issue was that in dsm.opt file was both schedlogname and errorlogname  pointing to paths that had spaced in it without using double quotes. 
And we have a issue also when installation script updated the password for the node and added to the registry. 

Related with issue #12 
